### PR TITLE
feat: use livox_sdk catkin package.

### DIFF
--- a/livox_ros_driver/CMakeLists.txt
+++ b/livox_ros_driver/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 #---------------------------------------------------------------------------------------
 # Compiler config
 #---------------------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/livox_ros_driver/CMakeLists.txt
+++ b/livox_ros_driver/CMakeLists.txt
@@ -14,44 +14,45 @@ message(STATUS "livox_ros_driver version: ${LIVOX_ROS_DRIVER_VERSION}")
 # find package and the dependecy
 #---------------------------------------------------------------------------------------
 find_package(Boost 1.54 REQUIRED COMPONENTS
-	system
-	thread
-	chrono
-	)
+    system
+    thread
+    chrono
+)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-	roscpp
-	rospy
-	sensor_msgs
-	std_msgs
-	message_generation
-	rosbag
-	pcl_ros
-	)
+    roscpp
+    rospy
+    sensor_msgs
+    std_msgs
+    message_generation
+    rosbag
+    pcl_ros
+    livox_sdk
+)
 
 ## Find pcl lib
 find_package(PCL REQUIRED)
 
 ## Generate messages in the 'msg' folder
 add_message_files(FILES
-	CustomPoint.msg
-	CustomMsg.msg
+    CustomPoint.msg
+    CustomMsg.msg
 #   Message2.msg
-	)
+)
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(DEPENDENCIES
-	std_msgs
-	)
+    std_msgs
+)
 
 find_package(PkgConfig)
 pkg_check_modules(APR apr-1)
 if (APR_FOUND)
-	message(${APR_INCLUDE_DIRS})
-	message(${APR_LIBRARIES})
+    message(${APR_INCLUDE_DIRS})
+    message(${APR_LIBRARIES})
 endif (APR_FOUND)
 
 ###################################
@@ -60,13 +61,17 @@ endif (APR_FOUND)
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
 ## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects als    o need
+## LIBRARIES: libraries you create in this project that dependent projects also need
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also n    eed
+## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(CATKIN_DEPENDS
-	roscpp rospy std_msgs message_runtime
-	pcl_ros
-	)
+    roscpp 
+    rospy 
+    std_msgs 
+    message_runtime
+    pcl_ros
+    livox_sdk
+)
 
 #---------------------------------------------------------------------------------------
 # Set default build to release
@@ -82,52 +87,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-## make sure the livox_sdk_static library is installed
-find_library(LIVOX_SDK_LIBRARY liblivox_sdk_static.a /usr/local/lib)
-
-if((NOT LIVOX_SDK_LIBRARY) OR (NOT EXISTS ${LIVOX_SDK_LIBRARY}))
-	# couldn't find the livox sdk library
-	message("Coudn't find livox sdk library!")
-	message("Download Livox-SDK from github and build&install it please!")
-	message("git clone Livox-SDK from github temporarily, only for ROS distro jenkins build!")
-
-	# clone livox sdk source code from github
-	execute_process(COMMAND rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK OUTPUT_VARIABLE cmd_res)
-	message("Try to pull the livox sdk source code from github")
-	FOREACH(res ${cmd_res})
-		MESSAGE(${res})
-	ENDFOREACH()
-
-	# Use the oxin-ros repo, which includes fixes to build the driver.
-	execute_process(COMMAND git clone https://github.com/oxin-ros/Livox-SDK.git ${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK OUTPUT_VARIABLE cmd_res)
-	FOREACH(res ${cmd_res})
-		MESSAGE(${res})
-	ENDFOREACH()
-
-	execute_process(COMMAND cmake .. WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK/build OUTPUT_VARIABLE cmd_res)
-	FOREACH(res ${cmd_res})
-		MESSAGE(${res})
-	ENDFOREACH()
-
-	execute_process(COMMAND make WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK/build OUTPUT_VARIABLE cmd_res)
-	FOREACH(res ${cmd_res})
-		MESSAGE(${res})
-	ENDFOREACH()
-
-	include_directories(
-		./
-		${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK/sdk_core/include
-	)
-
-	link_directories(
-		./
-		${CMAKE_CURRENT_SOURCE_DIR}/Livox-SDK/build/sdk_core
-	)
-
-else()
-	message("find livox sdk library success")
-endif()
-
 ## PCL library
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
@@ -135,41 +94,45 @@ add_definitions(${PCL_DEFINITIONS})
 #---------------------------------------------------------------------------------------
 # generate excutable and add libraries
 #---------------------------------------------------------------------------------------
-add_executable(${PROJECT_NAME}_node
+add_executable(
+    ${PROJECT_NAME}_node
     ""
-    )
+)
 
 #---------------------------------------------------------------------------------------
 # precompile macro and compile option
 #---------------------------------------------------------------------------------------
 target_compile_options(${PROJECT_NAME}_node
     PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>
-    )
+)
 
 #---------------------------------------------------------------------------------------
 # add projects that depend on
 #---------------------------------------------------------------------------------------
-add_dependencies(${PROJECT_NAME}_node ${PROJECT_NAME}_generate_messages_cpp)
+add_dependencies(
+    ${PROJECT_NAME}_node 
+    ${PROJECT_NAME}_generate_messages_cpp
+)
 
 #---------------------------------------------------------------------------------------
 # source file
 #---------------------------------------------------------------------------------------
 target_sources(${PROJECT_NAME}_node
-	PRIVATE
-	livox_ros_driver/lvx_file.cpp
-	livox_ros_driver/ldq.cpp
-	livox_ros_driver/lds.cpp
-	livox_ros_driver/lds_lvx.cpp
-	livox_ros_driver/lds_lidar.cpp
-	livox_ros_driver/lds_hub.cpp
-	livox_ros_driver/lddc.cpp
-	livox_ros_driver/livox_ros_driver.cpp
-	timesync/timesync.cpp
-	timesync/user_uart/user_uart.cpp
-	common/comm/comm_protocol.cpp
-	common/comm/sdk_protocol.cpp
-	common/comm/gps_protocol.cpp
-	)
+    PRIVATE
+    livox_ros_driver/lvx_file.cpp
+    livox_ros_driver/ldq.cpp
+    livox_ros_driver/lds.cpp
+    livox_ros_driver/lds_lvx.cpp
+    livox_ros_driver/lds_lidar.cpp
+    livox_ros_driver/lds_hub.cpp
+    livox_ros_driver/lddc.cpp
+    livox_ros_driver/livox_ros_driver.cpp
+    timesync/timesync.cpp
+    timesync/user_uart/user_uart.cpp
+    common/comm/comm_protocol.cpp
+    common/comm/sdk_protocol.cpp
+    common/comm/gps_protocol.cpp
+)
 
 #---------------------------------------------------------------------------------------
 # include file
@@ -186,18 +149,17 @@ target_include_directories(${PROJECT_NAME}_node
     timesync
     timesync/user_uart
     livox_ros_driver
-    )
+)
 
 #---------------------------------------------------------------------------------------
 # link libraries
 #---------------------------------------------------------------------------------------
 target_link_libraries(${PROJECT_NAME}_node
-	livox_sdk_static.a
-	${Boost_LIBRARY}
-	${catkin_LIBRARIES}
-	${PCL_LIBRARIES}
-	${APR_LIBRARIES}
-	)
+    ${Boost_LIBRARY}
+    ${catkin_LIBRARIES}
+    ${PCL_LIBRARIES}
+    ${APR_LIBRARIES}
+)
 
 
 #---------------------------------------------------------------------------------------
@@ -205,16 +167,16 @@ target_link_libraries(${PROJECT_NAME}_node
 #---------------------------------------------------------------------------------------
 
 install(TARGETS ${PROJECT_NAME}_node
-	ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-	)
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 install(DIRECTORY
-  launch
-  config
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-	)
+    launch
+    config
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 #---------------------------------------------------------------------------------------
 # end of CMakeList.txt

--- a/livox_ros_driver/package.xml
+++ b/livox_ros_driver/package.xml
@@ -2,52 +2,14 @@
 <package format="2">
   <name>livox_ros_driver</name>
   <version>2.0.0</version>
-  <description>The ROS device driver for Livox 3D LiDARs and Livox Hub</description>
+  <description>The ROS device driver for Livox 3D LiDARs and Livox Hub.</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="dev@livoxtech.com">Livox Dev Team</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/lidar_sdk</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
   <author email="dev@livoxtech.com">Livox Dev Team</author>
 
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
@@ -56,12 +18,14 @@
   <build_depend>message_generation</build_depend>
   <build_depend>rosbag</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>livox_sdk</build_depend>
 
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>rosbag</build_export_depend>
   <build_export_depend>pcl_ros</build_export_depend>
+  <build_export_depend>livox_sdk</build_export_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
@@ -69,14 +33,10 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosbag</exec_depend>
   <exec_depend>pcl_ros</exec_depend>
+  <exec_depend>livox_sdk</exec_depend>
 
   <depend>sensor_msgs</depend>
   <depend>git</depend>
   <depend>apr</depend>
   
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>


### PR DESCRIPTION
This PR removes the temporary Livox SDK build logic in favor of a catkin ROS package. 

This will require https://github.com/oxin-ros/Livox-SDK/pull/1