### PR TITLE
add user config path to launch args.

### DIFF
--- a/livox_ros_driver/launch/livox_hub.launch
+++ b/livox_ros_driver/launch/livox_hub.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="1"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="1"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_hub_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_hub_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_hub_msg.launch
+++ b/livox_ros_driver/launch/livox_hub_msg.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="1"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="1"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="1"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="1"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_hub_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_hub_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_hub_rviz.launch
+++ b/livox_ros_driver/launch/livox_hub_rviz.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="1"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="true"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="1"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="true"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_hub_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_hub_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_hub_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_lidar.launch
+++ b/livox_ros_driver/launch/livox_lidar.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="0"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="0"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_lidar_msg.launch
+++ b/livox_ros_driver/launch/livox_lidar_msg.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="1"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="0"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="1"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="0"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_lidar_nodelet.launch
+++ b/livox_ros_driver/launch/livox_lidar_nodelet.launch
@@ -1,38 +1,39 @@
 <launch>
 
-	<arg name="manager_name" default="livox_manager"/>
+    <arg name="manager_name" default="livox_manager"/>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="0"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="0"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
 
-	<node name="$(arg manager_name)" pkg="nodelet" type="nodelet" args="manager"  output="screen"/>
+    <node name="$(arg manager_name)" pkg="nodelet" type="nodelet" args="manager"  output="screen"/>
 
-	<node name="livox_lidar" pkg="nodelet" type="nodelet"
-		  args="load livox_ros_driver/LivoxRosDriverNodelet $(arg manager_name)" output="screen">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar" pkg="nodelet" type="nodelet"
+          args="load livox_ros_driver/LivoxRosDriverNodelet $(arg manager_name)" output="screen">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
 </launch>

--- a/livox_ros_driver/launch/livox_lidar_rviz.launch
+++ b/livox_ros_driver/launch/livox_lidar_rviz.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="0"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="true"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="0"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="true"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/livox_template.launch
+++ b/livox_ros_driver/launch/livox_template.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="0"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="0"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_lidar_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/lvx_to_rosbag.launch
+++ b/livox_ros_driver/launch/lvx_to_rosbag.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="2"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="1"/>
-	<arg name="rviz_enable" default="false"/>
-	<arg name="rosbag_enable" default="false"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="false"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="2"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="1"/>
+    <arg name="rviz_enable" default="false"/>
+    <arg name="rosbag_enable" default="false"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="false"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_hub_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_hub_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>

--- a/livox_ros_driver/launch/lvx_to_rosbag_rviz.launch
+++ b/livox_ros_driver/launch/lvx_to_rosbag_rviz.launch
@@ -1,48 +1,49 @@
 <launch>
 
-	<arg name="lvx_file_path" default="livox_test.lvx"/>
-	<arg name="bd_list" default="100000000000000"/>
-	<arg name="xfer_format" default="0"/>
-	<arg name="multi_topic" default="0"/>
-	<arg name="data_src" default="2"/>
-	<arg name="publish_freq" default="10.0"/>
-	<arg name="output_type" default="0"/>
-	<arg name="rviz_enable" default="true"/>
-	<arg name="rosbag_enable" default="true"/>
-	<arg name="cmdline_arg" default="$(arg bd_list)"/>
-	<arg name="lidar_msg_frame_id" default="livox_frame"/>
-	<arg name="imu_msg_frame_id" default="livox_frame"/>
-	<arg name="lidar_bag" default="true"/>
-	<arg name="imu_bag" default="true"/>
-	<arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
-	<arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="lvx_file_path" default="livox_test.lvx"/>
+    <arg name="bd_list" default="100000000000000"/>
+    <arg name="xfer_format" default="0"/>
+    <arg name="multi_topic" default="0"/>
+    <arg name="data_src" default="2"/>
+    <arg name="publish_freq" default="10.0"/>
+    <arg name="output_type" default="0"/>
+    <arg name="rviz_enable" default="true"/>
+    <arg name="rosbag_enable" default="true"/>
+    <arg name="cmdline_arg" default="$(arg bd_list)"/>
+    <arg name="lidar_msg_frame_id" default="livox_frame"/>
+    <arg name="imu_msg_frame_id" default="livox_frame"/>
+    <arg name="lidar_bag" default="true"/>
+    <arg name="imu_bag" default="true"/>
+    <arg name="angular_velocity_cov" default="[1.44e-4, 0, 0, 0, 1.44e-4, 0, 0, 0, 1.44e-4]"/>
+    <arg name="linear_acceleration_cov" default="[9.604e-3, 0, 0, 0, 9.604e-3, 0, 0, 0, 9.604e-3]"/>
+    <arg name="user_config_path" default="$(find livox_ros_driver)/config/livox_hub_config.json"/>
 
-	<node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
-		  required="true" output="screen" args="$(arg cmdline_arg)">
-		<param name="xfer_format" value="$(arg xfer_format)"/>
-		<param name="multi_topic" value="$(arg multi_topic)"/>
-		<param name="data_src" value="$(arg data_src)"/>
-		<param name="publish_freq" type="double" value="$(arg publish_freq)"/>
-		<param name="output_data_type" value="$(arg output_type)"/>
-		<param name="cmdline_str" type="string" value="$(arg bd_list)"/>
-		<param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
-		<param name="user_config_path" type="string" value="$(find livox_ros_driver)/config/livox_hub_config.json"/>
-		<param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
-		<param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
-		<param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
-		<param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
-		<rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
-		<rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
-	</node>
+    <node name="livox_lidar_publisher" pkg="livox_ros_driver" type="livox_ros_driver_node"
+          required="true" output="screen" args="$(arg cmdline_arg)">
+        <param name="xfer_format" value="$(arg xfer_format)"/>
+        <param name="multi_topic" value="$(arg multi_topic)"/>
+        <param name="data_src" value="$(arg data_src)"/>
+        <param name="publish_freq" type="double" value="$(arg publish_freq)"/>
+        <param name="output_data_type" value="$(arg output_type)"/>
+        <param name="cmdline_str" type="string" value="$(arg bd_list)"/>
+        <param name="cmdline_file_path" type="string" value="$(arg lvx_file_path)"/>
+        <param name="user_config_path" type="string" value="$(arg user_config_path)"/>
+        <param name="lidar_frame_id" type="string" value="$(arg lidar_msg_frame_id)"/>
+        <param name="imu_frame_id" type="string" value="$(arg imu_msg_frame_id)"/>
+        <param name="enable_lidar_bag" type="bool" value="$(arg lidar_bag)"/>
+        <param name="enable_imu_bag" type="bool" value="$(arg imu_bag)"/>
+        <rosparam param="angular_velocity_cov">$(arg angular_velocity_cov)</rosparam>
+        <rosparam param="linear_acceleration_cov">$(arg linear_acceleration_cov)</rosparam>
+    </node>
 
-	<group if="$(arg rviz_enable)">
-		<node name="rviz" pkg="rviz" type="rviz" respawn="true"
-				args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
+    <group if="$(arg rviz_enable)">
+        <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+                args="-d $(find livox_ros_driver)/config/display_lidar_points.rviz"/>
     </group>
 
-	<group if="$(arg rosbag_enable)">
-    	<node pkg="rosbag" type="record" name="record" output="screen"
-          		args="-a"/>
+    <group if="$(arg rosbag_enable)">
+        <node pkg="rosbag" type="record" name="record" output="screen"
+                  args="-a"/>
     </group>
 
 </launch>


### PR DESCRIPTION
This adds the ability to specify the user config path to the livox_ros_driver launch files. This is useful to allow the user to specify a non-default config file when launching the lidar.